### PR TITLE
fix: editor mouseout will hide hover widget

### DIFF
--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -87,7 +87,14 @@ export class ModesHoverController implements IEditorContribution {
 			this._toUnhook.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
 		}
 
-		this._toUnhook.add(this._editor.onMouseLeave(hideWidgetsEventHandler));
+		this._toUnhook.add(this._editor.onMouseLeave((e) => {
+			const targetEm = (e.event.browserEvent.relatedTarget) as HTMLElement;
+			if (this._contentWidget?.getDomNode()?.contains(targetEm)) {
+				// 如果 onMouseLeave 后鼠标是在 hover widget 内，则不隐藏
+				return;
+			}
+			hideWidgetsEventHandler();
+		}));
 		this._toUnhook.add(this._editor.onDidChangeModel(hideWidgetsEventHandler));
 		this._toUnhook.add(this._editor.onDidScrollChange((e: IScrollEvent) => this._onEditorScrollChanged(e)));
 	}


### PR DESCRIPTION
The hover listens to mouse events from the editor
and since it is now rooted via overflowWidgetsDomNode outside the editor
it does not receive the editor mouse events anymore.

so this commit use a condition to solve that.

This PR fixes https://github.com/opensumi/core/issues/124
