### PR TITLE
fix: view zone position in diffEditor with hidden area

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1452,7 +1452,37 @@ abstract class ViewZonesComputer {
 		return (endLineNumber - startLineNumber + 1);
 	}
 
+	/**
+	 * get actual line number from relative line number with hidden range information
+	 * @param lineNumber line number without hiddenAreas
+	 * @param hiddenRanges editor hidden ranges
+	 * @returns actual line number
+	 */
+	private getActualLineNumber(lineNumber: number, hiddenRanges?: IRange[]) {
+		if (!hiddenRanges?.length) {
+			return lineNumber;
+		}
+		if (hiddenRanges.length === 1) {
+			return lineNumber > hiddenRanges[0].startLineNumber - 1 ? lineNumber + hiddenRanges[0].endLineNumber - hiddenRanges[0].startLineNumber + 1 : lineNumber;
+		}
+		let prevCollapseLine = 0;
+		let count = 0;
+		let totalGap = 0;
+		// find the last hidden range before lineNumber and add the line count
+		for (let i = 0; i < hiddenRanges.length; i++) {
+			totalGap += hiddenRanges[i].startLineNumber - prevCollapseLine - 1;
+			if (totalGap >= lineNumber) {
+				break;
+			}
+			prevCollapseLine = hiddenRanges[i].endLineNumber;
+			count += hiddenRanges[i].endLineNumber - hiddenRanges[i].startLineNumber + 1;
+		}
+		return lineNumber + count;
+	}
+
 	public getViewZones(): IEditorsZones {
+		const modifiedHiddenRanges = this._modifiedEditor._getViewModel()?.hiddenAreas;
+		const originalHiddenRanges = this._originalEditor._getViewModel()?.hiddenAreas;
 		const originalLineHeight = this._originalEditor.getOption(EditorOption.lineHeight);
 		const modifiedLineHeight = this._modifiedEditor.getOption(EditorOption.lineHeight);
 		const originalHasWrapping = (this._originalEditor.getOption(EditorOption.wrappingInfo).wrappingColumn !== -1);
@@ -1563,16 +1593,17 @@ abstract class ViewZonesComputer {
 			}
 
 			// [PRODUCE] View zone(s) in original-side due to foreign view zone(s) in modified-side
-			while (modifiedForeignVZ.current && modifiedForeignVZ.current.afterLineNumber <= modifiedEndEquivalentLineNumber) {
+			while (modifiedForeignVZ.current && this.getActualLineNumber(modifiedForeignVZ.current.afterLineNumber, modifiedHiddenRanges) <= modifiedEndEquivalentLineNumber) {
 				let viewZoneLineNumber: number;
-				if (modifiedForeignVZ.current.afterLineNumber <= modifiedEquivalentLineNumber) {
-					viewZoneLineNumber = originalEquivalentLineNumber - modifiedEquivalentLineNumber + modifiedForeignVZ.current.afterLineNumber;
+				const actualAfterLineNumber = this.getActualLineNumber(modifiedForeignVZ.current.afterLineNumber, modifiedHiddenRanges);
+				if (actualAfterLineNumber <= modifiedEquivalentLineNumber) {
+					viewZoneLineNumber = originalEquivalentLineNumber - modifiedEquivalentLineNumber + actualAfterLineNumber;
 				} else {
 					viewZoneLineNumber = originalEndEquivalentLineNumber;
 				}
 
 				let marginDomNode: HTMLDivElement | null = null;
-				if (lineChange && lineChange.modifiedStartLineNumber <= modifiedForeignVZ.current.afterLineNumber && modifiedForeignVZ.current.afterLineNumber <= lineChange.modifiedEndLineNumber) {
+				if (lineChange && lineChange.modifiedStartLineNumber <= actualAfterLineNumber && actualAfterLineNumber <= lineChange.modifiedEndLineNumber) {
 					marginDomNode = this._createOriginalMarginDomNodeForModifiedForeignViewZoneInAddedRegion();
 				}
 
@@ -1586,10 +1617,11 @@ abstract class ViewZonesComputer {
 			}
 
 			// [PRODUCE] View zone(s) in modified-side due to foreign view zone(s) in original-side
-			while (originalForeignVZ.current && originalForeignVZ.current.afterLineNumber <= originalEndEquivalentLineNumber) {
+			while (originalForeignVZ.current && this.getActualLineNumber(originalForeignVZ.current.afterLineNumber, originalHiddenRanges) <= originalEndEquivalentLineNumber) {
 				let viewZoneLineNumber: number;
-				if (originalForeignVZ.current.afterLineNumber <= originalEquivalentLineNumber) {
-					viewZoneLineNumber = modifiedEquivalentLineNumber - originalEquivalentLineNumber + originalForeignVZ.current.afterLineNumber;
+				const actualAfterLineNumber = this.getActualLineNumber(originalForeignVZ.current.afterLineNumber, originalHiddenRanges);
+				if (actualAfterLineNumber <= originalEquivalentLineNumber) {
+					viewZoneLineNumber = modifiedEquivalentLineNumber - originalEquivalentLineNumber + actualAfterLineNumber;
 				} else {
 					viewZoneLineNumber = modifiedEndEquivalentLineNumber;
 				}

--- a/src/vs/editor/common/viewModel/viewModel.ts
+++ b/src/vs/editor/common/viewModel/viewModel.ts
@@ -307,6 +307,8 @@ export interface IViewModel extends ICursorSimpleModel {
 
 	readonly cursorConfig: CursorConfiguration;
 
+	readonly hiddenAreas: IRange[];
+
 	addViewEventHandler(eventHandler: ViewEventHandler): void;
 	removeViewEventHandler(eventHandler: ViewEventHandler): void;
 

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -441,6 +441,10 @@ export class ViewModel extends Disposable implements IViewModel {
 		}));
 	}
 
+	public get hiddenAreas() {
+		return this._lines.getHiddenAreas();
+	}
+
 	public setHiddenAreas(ranges: Range[]): void {
 		try {
 			const eventsCollector = this._eventDispatcher.beginEmitViewEvents();


### PR DESCRIPTION
修复 diffEditor 存在 hiddenArea 时，可能导致 viewZone 对应的阴影位置计算不正确问题