### PR TITLE
chore: 支持启用只读模式下的codeAction

### DIFF
--- a/src/vs/editor/contrib/codeAction/codeActionModel.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionModel.ts
@@ -229,7 +229,7 @@ export class CodeActionModel extends Disposable {
 		const model = this._editor.getModel();
 		if (model
 			&& CodeActionProviderRegistry.has(model)
-			&& !this._editor.getOption(EditorOption.readOnly)
+			&& (!this._editor.getOption(EditorOption.readOnly) || this._editor.getOption(EditorOption.renderValidationDecorations) === 'on')
 		) {
 			const supportedActions: string[] = [];
 			for (const provider of CodeActionProviderRegistry.all(model)) {

--- a/src/vs/editor/contrib/hover/markerHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/markerHoverParticipant.ts
@@ -179,7 +179,7 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 			});
 		}
 
-		if (!this._editor.getOption(EditorOption.readOnly)) {
+		if (!this._editor.getOption(EditorOption.readOnly) || this._editor.getOption(EditorOption.renderValidationDecorations) === 'on') {
 			const quickfixPlaceholderElement = statusBar.append($('div'));
 			if (this.recentMarkerCodeActionsInfo) {
 				if (IMarkerData.makeKey(this.recentMarkerCodeActionsInfo.marker) === IMarkerData.makeKey(markerHover.marker)) {


### PR DESCRIPTION
editorOption 传入 `renderValidationDecorations: 'on'` 时，允许 CodeAction 正常展示
![image](https://user-images.githubusercontent.com/13199771/154884173-daa8bd26-29b9-41a2-91d4-e7ae357b03e8.png)
